### PR TITLE
Change "Honeyswap/Uniswap" to "Baoswap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# Honeyswap Interface
+# Baoswap Interface
 
 [![Tests](https://github.com/Uniswap/uniswap-interface/workflows/Tests/badge.svg)](https://github.com/Uniswap/uniswap-interface/actions?query=workflow%3ATests)
 [![Styled With Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://prettier.io/)
 
-An open source interface for Honeyswap -- a protocol for decentralized exchange of xDai tokens.
+An open source interface for Baoswap -- a protocol for decentralized exchange of Bao tokens.
 
 - Interface: [baoswap.xyz](https://baoswap.xyz/)
 - Docs: [docs.bao.finance](https://about.1hive.org/docs/honeyswap)
 - Twitter: [@thebaoman](https://twitter.com/thebaoman)
 - Discord: [Bao Finance Discord](https://discord.gg/BW3P62vJXT)
 
-## Accessing the Uniswap Interface
+## Accessing the Baoswap Interface
 
-To access the Uniswap Interface, use an IPFS gateway link from the
+To access the Baoswap Interface, use an IPFS gateway link from the
 [latest release](https://github.com/1Hive/uniswap-interface/releases/latest),
 or visit [baoswap.xyz](https://baoswap.xyz).
 


### PR DESCRIPTION
Fix #5 

Hello @thebaoman `README.md` has "Honeyswap Interface" and "Uniswap Interface" text. This Pull Request changes these to "Baoswap Interface"