### PR TITLE
Change "Honeyswap" text to "Baoswap" on /remove/v1/:address page 

### DIFF
--- a/src/pages/MigrateV1/RemoveV1Exchange.tsx
+++ b/src/pages/MigrateV1/RemoveV1Exchange.tsx
@@ -111,7 +111,7 @@ function V1PairRemoval({
         </div>
       </LightCard>
       <TYPE.darkGray style={{ textAlign: 'center' }}>
-        {`Your Honeyswap V1 ${
+        {`Your Baoswap V1 ${
           chainId && token.equals(WETH[chainId]) ? 'WETH' : token.symbol
         }/ETH liquidity will be redeemed for underlying assets.`}
       </TYPE.darkGray>
@@ -134,7 +134,7 @@ export default function RemoveV1Exchange({
   const liquidityToken: Token | undefined = useMemo(
     () =>
       validatedAddress && chainId && token
-        ? new Token(chainId, validatedAddress, 18, `UNI-V1-${token.symbol}`, 'Honeyswap V1')
+        ? new Token(chainId, validatedAddress, 18, `UNI-V1-${token.symbol}`, 'Baoswap V1')
         : undefined,
     [chainId, validatedAddress, token]
   )
@@ -153,7 +153,7 @@ export default function RemoveV1Exchange({
           <BackArrow to="/migrate/v1" />
           <TYPE.mediumHeader>Remove V1 Liquidity</TYPE.mediumHeader>
           <div>
-            <QuestionHelper text="Remove your Honeyswap V1 liquidity tokens." />
+            <QuestionHelper text="Remove your Baoswap V1 liquidity tokens." />
           </div>
         </AutoRow>
 


### PR DESCRIPTION
Fix #9 

Hello @thebaoman this Pull Request replaces "Honeyswap" text with "Baoswap" on `/remove/v1/:address` page

![image](https://user-images.githubusercontent.com/18475870/108144523-7e81c480-708f-11eb-86bf-0d01f322046d.png)