### PR TITLE
Fix reference to "master" branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ The interface will not work on other networks.
 
 ## Contributions
 
-**Please open all pull requests against the `master` branch.**
+**Please open all pull requests against the `main` branch.**
 CI checks will run against all PRs.


### PR DESCRIPTION
Fix #11 

This PR changes "Please open all pull requests against the `master` branch." to "Please open all pull requests against the `main` branch." in `README.md` file