### PR TITLE
Update transparency in 'advancedBG' value to be compatible w/ advanced swap details

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -61,7 +61,7 @@ export function colors(darkMode: boolean): Colors {
 
     //specialty colors
     modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
-    advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',
+    advancedBG: darkMode ? 'rgba(0,0,0,0.65)' : 'rgba(255,255,255,0.6)',
 
     //primary colors
     primary1: darkMode ? '#26a697' : '#1974D2',


### PR DESCRIPTION
This PR changes the dark mode `advancedBG` theme variable to have an alpha value of `0.65` instead of `0.1`. This leads to the "advanced swap details" being more readable when the theme is set to dark mode (before and after shown below).

The `advancedBG` theme variable is only used in the `AdvancedDetailsFooter` and `ButtonEmpty` components, but `ButtonEmpty` is unused, so the advanced swap details should only be affected.

I've run this locally to confirm it works. 

<img width="477" alt="Screen Shot 2021-03-01 at 7 17 35 PM" src="https://user-images.githubusercontent.com/76754976/109543285-61ed7f80-7ac6-11eb-828f-90ac4536ef1a.png">
<img width="494" alt="Screen Shot 2021-03-01 at 7 34 11 PM" src="https://user-images.githubusercontent.com/76754976/109543291-63b74300-7ac6-11eb-826b-5e601427587f.png">
