### PR TITLE
Change dark mode advancedBG transparency to 0.6

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -61,7 +61,7 @@ export function colors(darkMode: boolean): Colors {
 
     //specialty colors
     modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
-    advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',
+    advancedBG: darkMode ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.6)',
 
     //primary colors
     primary1: darkMode ? '#26a697' : '#1974D2',


### PR DESCRIPTION
Fix #26 

This Pull Request changes the `advancedBG` transparency per somethingElse's suggestion on discord (kudos somethingElse 👍) 

![image](https://user-images.githubusercontent.com/18475870/109556766-d7dcf100-7a9c-11eb-9f19-2d64b6c5d4ed.png)

###### ----------------------------------------------------------------------------
###### Tips :) (BAO on ETH or xDAI) 0x047C9678BF11753f028735e602bB34FEe3A742AD
![image](https://user-images.githubusercontent.com/18475870/108159434-a6cbec00-70ac-11eb-9fcd-7c751b4151b7.png)